### PR TITLE
Erlang/OTP 21.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
-install:
-  - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
 language: erlang
 otp_release:
+  - 21.0
+  - 20.3
+  - 19.3
   - 18.3
-  - 18.2.1
-  - 18.2
-  - 18.1
-  - 18.0
-script:
-  - ./rebar3 compile 
-  - ./rebar3 eunit
+script: rebar3 do compile, eunit

--- a/src/esaml_cowboy.erl
+++ b/src/esaml_cowboy.erl
@@ -44,7 +44,7 @@ reply_with_authnreq(SP, IDP, RelayState, Req) ->
     undefined | xml_callback_fun(),
     undefined | xml_callback_state()) -> {ok, Req}.
 reply_with_authnreq(SP, IDP, RelayState, Req, User_Name_Id, Xml_Callback, Xml_Callback_State) ->
-    SignedXml = SP:generate_authn_request(IDP),
+    SignedXml = esaml_sp:generate_authn_request(IDP, SP),
     is_function(Xml_Callback, 2) andalso Xml_Callback(SignedXml, Xml_Callback_State),
     reply_with_req(IDP, SignedXml, User_Name_Id, RelayState, Req).
 
@@ -54,7 +54,7 @@ reply_with_authnreq(SP, IDP, RelayState, Req, User_Name_Id, Xml_Callback, Xml_Ca
 %% wish to log out.
 -spec reply_with_logoutreq(esaml:sp(), IdPSLOEndpoint :: uri(), NameID :: string(), Req) -> {ok, Req}.
 reply_with_logoutreq(SP, IDP, NameID, Req) ->
-    SignedXml = SP:generate_logout_request(IDP, NameID),
+    SignedXml = esaml_sp:generate_logout_request(IDP, NameID, SP),
     reply_with_req(IDP, SignedXml, undefined, <<>>, Req).
 
 %% @doc Reply to a Cowboy request with a LogoutResponse payload
@@ -63,7 +63,7 @@ reply_with_logoutreq(SP, IDP, NameID, Req) ->
 %% received to allow the IdP to keep state.
 -spec reply_with_logoutresp(esaml:sp(), IdPSLOEndpoint :: uri(), esaml:status_code(), RelayState :: binary(), Req) -> {ok, Req}.
 reply_with_logoutresp(SP, IDP, Status, RelayState, Req) ->
-    SignedXml = SP:generate_logout_response(IDP, Status),
+    SignedXml = esaml_sp:generate_logout_response(IDP, Status, SP),
     reply_with_req(IDP, SignedXml, undefined, RelayState, Req).
 
 %% @private
@@ -132,12 +132,12 @@ validate_logout(SP, SAMLEncoding, SAMLResponse, RelayState, Req2) ->
                   {"saml", 'urn:oasis:names:tc:SAML:2.0:assertion'}],
             case xmerl_xpath:string("/samlp:LogoutRequest", Xml, [{namespace, Ns}]) of
                 [#xmlElement{}] ->
-                    case SP:validate_logout_request(Xml) of
+                    case esaml_sp:validate_logout_request(Xml, SP) of
                         {ok, Reqq} -> {request, Reqq, RelayState, Req2};
                         Err -> Err
                     end;
                 _ ->
-                    case SP:validate_logout_response(Xml) of
+                    case esaml_sp:validate_logout_response(Xml, SP) of
                         {ok, Resp} -> {response, Resp, RelayState, Req2};
                         Err -> Err
                     end
@@ -147,7 +147,7 @@ validate_logout(SP, SAMLEncoding, SAMLResponse, RelayState, Req2) ->
 %% @doc Reply to a Cowboy request with a Metadata payload
 -spec reply_with_metadata(esaml:sp(), Req) -> {ok, Req}.
 reply_with_metadata(SP, Req) ->
-    SignedXml = SP:generate_metadata(),
+    SignedXml = esaml_sp:generate_metadata(SP),
     Metadata = xmerl:export([SignedXml], xmerl_xml),
     cowboy_req:reply(200, [{<<"Content-Type">>, <<"text/xml">>}], Metadata, Req).
 


### PR DESCRIPTION
In Erlang/OTP 21.1, support for tuple calls is removed from the runtime.