### PR TITLE
Erlang 21.x compatibility

### DIFF
--- a/src/esaml_cowboy.erl
+++ b/src/esaml_cowboy.erl
@@ -180,7 +180,7 @@ validate_assertion(SP, DuplicateFun, Custom_Response_Security_Callback, Callback
         {'EXIT', Reason} ->
             {error, {bad_decode, Reason}, Req2};
         Xml ->
-            case SP:validate_assertion(Xml, DuplicateFun) of
+            case esaml_sp:validate_assertion(Xml, DuplicateFun, SP) of
                 {ok, A}     -> perform_extra_security_if_applicable(Custom_Response_Security_Callback, Callback_State, Xml, A, RelayState, Req2);
                 {error, E}  -> {error, E, Req2}
             end


### PR DESCRIPTION
Support for tuple calls was removed in the 21.x line

This one seems to have slipped through the cracks in #5 