### PR TITLE
Prevent dupe namespaces in c14n

### DIFF
--- a/src/xmerl_c14n.erl
+++ b/src/xmerl_c14n.erl
@@ -26,7 +26,7 @@
 canon_name(Ns, Name, Nsp) ->
     NsPartRaw = case Ns of
         empty -> Nsp#xmlNamespace.default;
-        [] -> 
+        [] ->
             if Nsp == [] -> 'urn:oasis:names:tc:SAML:2.0:assertion';
                true -> Nsp#xmlNamespace.default
             end;
@@ -102,7 +102,7 @@ needed_ns(#xmlElement{nsinfo = NsInfo, attributes = Attrs}, InclNs) ->
     lists:foldl(fun(Attr, Needed) ->
         case Attr#xmlAttribute.nsinfo of
             {"xmlns", Prefix} ->
-                case lists:member(Prefix, InclNs) of
+                case lists:member(Prefix, InclNs) and not lists:member(Prefix, Needed) of
                     true -> [Prefix | Needed];
                     _ -> Needed
                 end;
@@ -377,5 +377,10 @@ c14n_inclns_test() ->
 
     Target2 = "<foo:a xmlns:bar=\"urn:bar:\" xmlns:foo=\"urn:foo:\"><foo:b bar:nothing=\"something\">foo</foo:b></foo:a>",
     Target2 = c14n(Doc, false, ["bar"]).
+
+c14n_dont_dupe_ns_test() ->
+  {Doc, []} = xmerl_scan:string("<foo:a xmlns:foo=\"urn:foo:\"><foo:b xmlns:bar=\"urn:bar:\" bar:nothing=\"something\">foo</foo:b></foo:a>", [{namespace_conformant, true}]),
+  Target1 = "<foo:a xmlns:foo=\"urn:foo:\"><foo:b xmlns:bar=\"urn:bar:\" bar:nothing=\"something\">foo</foo:b></foo:a>",
+  Target1 = c14n(Doc, false, ["foo", "bar"]).
 
 -endif.


### PR DESCRIPTION
While debugging a digest mismatch, I noticed duped `xmlns` declarations. I tracked it back to `InclusiveNamespaces` from the SAML assertion. I then noticed while collecting needed namespaces from attrs, if it finds a xmlns declaration, it will push it into the list regardless if it was already in the needed namespace list. The other condition on the case, when the attribute is not an `xmlns` declaration, has a check to prevent dupes. This code branch was probably missing the check because you expect the xmlns to come first and you expect none of them to be duplicated. I don't think there are any guarantees that the xmlns would come before an attribute that used the namespace, so it may even fail for valid xml that doesn't use `InclusiveNamespaces` unless xmerl, or other code, sorts the attributes to put xmlns first before this function is called.

I could only see this breaking other integrations if someone intentionally sent duplicate xmlns statements and the signature depended on them. That doesn't seem like a likely scenario to me. Seems more likely the c14n would prohibit that, or that standard has a very different definition of "canonical" than I.