### PR TITLE
sp metadata signatures can not be verified correctly

### DIFF
--- a/src/esaml.erl
+++ b/src/esaml.erl
@@ -569,10 +569,11 @@ to_xml(#esaml_logoutresp{version = V, issue_instant  = Time,
       ],
 
       OrganizationElem = #xmlElement{name = 'md:Organization',
-          content =
-              lang_elems(#xmlElement{name = 'md:OrganizationName'}, OrgName) ++
-              lang_elems(#xmlElement{name = 'md:OrganizationDisplayName'}, OrgDisplayName) ++
-              lang_elems(#xmlElement{name = 'md:OrganizationURL'}, OrgUrl)
+          content =[
+             #xmlElement{name = 'md:OrganizationName', content = [#xmlText{value = OrgName}]},
+             #xmlElement{name = 'md:OrganizationDisplayName', content = [#xmlText{value = OrgDisplayName}]},
+             #xmlElement{name = 'md:OrganizationURL', content = [#xmlText{value = OrgUrl}]}
+         ]
       },
 
       ContactElem = #xmlElement{name = 'md:ContactPerson',


### PR DESCRIPTION
We ran into this issue when trying to import signed metadata into Active Directory.

Apparently, the xml:lang="en" attribute breaks some signature methods.

Same issue, different project:
https://stackoverflow.com/questions/45655516/golang-goxmldig-signature-verification-failed

We used https://github.com/clarin-eric/SAML-metadata-checker to verify the metadata.  It fails when the attributes are present and passes when removed.

I'm not entirely sure if this is the correct fix, but it is the fix that is working for us.