### PR TITLE
Support OTP 24

### DIFF
--- a/include/esaml.hrl
+++ b/include/esaml.hrl
@@ -107,7 +107,7 @@
 	idp_signs_envelopes = true :: boolean(),
 	idp_signs_logout_requests = true :: boolean(),
 	sp_sign_metadata = false :: boolean(),
-	trusted_fingerprints = [] :: [string() | binary()],
+	trusted_fingerprints = [] :: [string() | binary()] | any,
 	metadata_uri = "" :: string(),
 	consume_uri = "" :: string(),
 	logout_uri :: string() | undefined,

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -146,7 +146,10 @@ generate_metadata(SP = #esaml_sp{org = Org, tech = Tech}) ->
 -spec setup(esaml:sp()) -> esaml:sp().
 setup(SP = #esaml_sp{trusted_fingerprints = FPs, metadata_uri = MetaURI,
                      consume_uri = ConsumeURI}) ->
-    Fingerprints = esaml_util:convert_fingerprints(FPs),
+    Fingerprints = case FPs of
+        any -> any;
+        _ -> esaml_util:convert_fingerprints(FPs)
+    end,
     case MetaURI of "" -> error("must specify metadata URI"); _ -> ok end,
     case ConsumeURI of "" -> error("must specify consume URI"); _ -> ok end,
     if (SP#esaml_sp.key =:= undefined) andalso (SP#esaml_sp.sp_sign_requests) ->

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -337,18 +337,18 @@ block_decrypt("http://www.w3.org/2009/xmlenc11#aes128-gcm", SymmetricKey, Cipher
     %% IV: 12 bytes and Tag data: 16 bytes
     EncryptedDataSize = byte_size(CipherValue) - 12 - 16,
     <<IV:12/binary, EncryptedData:EncryptedDataSize/binary, Tag:16/binary>> = CipherValue,
-    DecryptedData = crypto:block_decrypt(aes_gcm, SymmetricKey, IV, {<<>>, EncryptedData, Tag}),
+    DecryptedData = crypto:crypto_one_time_aead(aes_128_gcm, SymmetricKey, IV, EncryptedData, <<>>, Tag, false),
     binary_to_list(DecryptedData);
 
 block_decrypt("http://www.w3.org/2001/04/xmlenc#aes128-cbc", SymmetricKey, CipherValue) ->
     <<IV:16/binary, EncryptedData/binary>> = CipherValue,
-    DecryptedData = crypto:block_decrypt(aes_cbc128, SymmetricKey, IV, EncryptedData),
+    DecryptedData = crypto:crypto_one_time(aes_128_cbc, SymmetricKey, IV, EncryptedData, false),
     IsPadding = fun(X) -> X < 16 end,
     lists:reverse(lists:dropwhile(IsPadding, lists:reverse(binary_to_list(DecryptedData))));
 
 block_decrypt("http://www.w3.org/2001/04/xmlenc#aes256-cbc", SymmetricKey, CipherValue) ->
     <<IV:16/binary, EncryptedData/binary>> = CipherValue,
-    DecryptedData = crypto:block_decrypt(aes_cbc256, SymmetricKey, IV, EncryptedData),
+    DecryptedData = crypto:crypto_one_time(aes_256_cbc, SymmetricKey, IV, EncryptedData, false),
     IsPadding = fun(X) -> X < 16 end,
     lists:reverse(lists:dropwhile(IsPadding, lists:reverse(binary_to_list(DecryptedData)))).
 


### PR DESCRIPTION
`crypto:block_decrypt` was [deprecated](https://erlang.org/doc/apps/crypto/new_api.html#the-old-api) in OTP 23 and has been removed in OTP 24. This PR uses the [new API](https://erlang.org/doc/apps/crypto/new_api.html#the-new-api).